### PR TITLE
Expose Etag header

### DIFF
--- a/lib/web/app.js
+++ b/lib/web/app.js
@@ -157,6 +157,7 @@ function corsHeaders(req, res, next) {
 		'Access-Control-Allow-Origin':'*',
 		'Access-Control-Allow-Method': 'GET',
 		'Access-Control-Allow-Headers': 'X-Requested-With, ETag',
+		'Access-Control-Expose-Headers':'ETag',
 		'Server': 'Bertha'
 	});
 


### PR DESCRIPTION
Adding Access-Control-Expose-Headers to expose the ETag to other apps (e.g. US Election 2020: fixes https://github.com/Financial-Times/ig-us-election-2020/issues/312)